### PR TITLE
Check for boolean values of LABEL/BUMP

### DIFF
--- a/js/feature-tier.js
+++ b/js/feature-tier.js
@@ -1496,10 +1496,10 @@ function glyphForFeature(feature, y, style, tier, forceHeight)
         glyph.dalliance_feature = feature;
     }
     var dg = new DGlyph(glyph, min, max, requiredHeight);
-    if (style.LABEL && (feature.label || feature.id)) {
+    if (style.LABEL == 'yes' && (feature.label || feature.id)) {
         dg.label = feature.label || feature.id;
     }
-    if (style.BUMP) {
+    if (style.BUMP == 'yes') {
         dg.bump = true;
     }
     dg.strand = feature.orientation || '0';


### PR DESCRIPTION
This is a bugfix. The feature tier only checked for the mere presence of the boolean parameters LABEL and BUMP. This would cause them to be interpreted as true when they were explicitly set to 'no' (false).

The fix checks explicitly for the value 'yes'. According to DAS spec 1.6, the values can only be either 'yes' or 'no', so I am not handling case sensitivity here.
