### PR TITLE
Init browser if document has already loaded

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -141,7 +141,12 @@ function Browser(opts) {
     this.workerPath = '$$js/fetchworker.js';
 
     var thisB = this;
-    window.addEventListener('load', function(ev) {thisB.realInit();}, false);
+
+    if (document.readyState === 'complete') {
+        thisB.realInit();
+    } else {
+        window.addEventListener('load', function(ev) {thisB.realInit();}, false);
+    }
 }
 
 Browser.prototype.resolveURL = function(url) {


### PR DESCRIPTION
I had problems embedding Dalliance as I instantiated the browser after the load event has been fired. This commit adds a check if `document.readyState` is already `complete` in which case `realInit()` is called right away. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/document.readyState) `document.readyState === 'complete'` is equal to the load event.
