### PR TITLE
Fetch seqinfo if it is not fully initialized in setLocation

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -1540,7 +1540,7 @@ Browser.prototype.setLocation = function(newChr, newMin, newMax, callback) {
     }
     var thisB = this;
 
-    if (!newChr || newChr == this.chr) {
+    if ((!newChr || newChr == this.chr) && this.currentSeqMax > 0) {
         return this._setLocation(null, newMin, newMax, null, callback);
     } else {
         var ss = this.getSequenceSource();


### PR DESCRIPTION
@dasmoth

Fixes immediate issue of https://github.com/dasmoth/dalliance/issues/70.

It is possible more could be done to prevent `currentSeqMax` for being uninitialized in the first place https://github.com/dasmoth/dalliance/issues/70#issuecomment-49196187.
