### PR TITLE
Small fix in sourceBlocksForRange

### DIFF
--- a/js/chainset.js
+++ b/js/chainset.js
@@ -205,7 +205,7 @@ Chainset.prototype.unmapPoint = function(chr, pos) {
 Chainset.prototype.sourceBlocksForRange = function(chr, min, max, callback) {
     var thisCS = this;
     var minTile = (min/this.granularity)|0;
-    var maxTile = (min/this.granularity)|0;
+    var maxTile = (max/this.granularity)|0;
 
     var needsNewFetch = false;
     for (var t = minTile; t <= maxTile; ++t) {


### PR DESCRIPTION
@dasmoth

I think there's a typo for `max` in the `sourceBlocksForRange` function? 

Found this when trying to fetch a really mapping (that's greater than the `granularity` set at 1,000,000 bases) and got an incomplete fetching of source blocks.
