### PR TITLE
Retaining feature popup fields for MappedFeatureSource

### DIFF
--- a/js/sourceadapters.js
+++ b/js/sourceadapters.js
@@ -1361,6 +1361,11 @@ MappedFeatureSource.prototype.getScales = function() {
     return this.source.getScales();
 }
 
+MappedFeatureSource.prototype.getDefaultFIPs = function(callback) {
+    if (this.source.getDefaultFIPs)
+        return this.source.getDefaultFIPs(callback);
+}
+
 MappedFeatureSource.prototype.simplifySegments = function(segs, minGap) {
     if (segs.length == 0) return segs;
 


### PR DESCRIPTION
@dasmoth cc @mdrasmus

When feature tracks are lifted-over using a mapping chain, some fields in the feature pop-up which are populated by default ([for example](https://github.com/dasmoth/dalliance/blob/master/js/vcf.js#L146), in `vcfParser` for a VCF file) are lost.

This PR propagates the  `getDefatulFIPs` function of underlying feature source of `MappedFeatureSource` to ensure that such feature pop-up information are retained. 

This seems to be the desired behavior from my use cases, and thought others might find it useful. :)
