### PR TITLE
Add missing import for saltURL in bin.js

### DIFF
--- a/js/bin.js
+++ b/js/bin.js
@@ -12,6 +12,7 @@
 if (typeof(require) !== 'undefined') {
     var utils = require('./utils');
     var shallowCopy = utils.shallowCopy;
+    var saltURL = utils.saltURL;
 
     var sha1 = require('./sha1');
     var b64_sha1 = sha1.b64_sha1;

--- a/js/utils.js
+++ b/js/utils.js
@@ -456,6 +456,7 @@ if (typeof(module) !== 'undefined') {
         textXHR: textXHR,
         relativeURL: relativeURL,
         resolveUrlToPage: resolveUrlToPage,
+        saltURL: saltURL,
         shallowCopy: shallowCopy,
         pusho: pusho,
         pushnew: pushnew,


### PR DESCRIPTION
@dasmoth 

There seems to be a unresolved `saltURL` variable in `bin.js`, which seems to be solved by importing it from `utils`.

Discovered this when I was trying a Trix-based gene search on a Safari, which triggered an exception:

![screen shot 2014-08-25 at 6 22 07 pm](https://cloud.githubusercontent.com/assets/7988161/4038899/b7b375c0-2cbf-11e4-9e1c-424f7e0ecfad.png)
