### PR TITLE
Promise require missing for kspace. Problem found using safari.

### DIFF
--- a/js/kspace.js
+++ b/js/kspace.js
@@ -37,6 +37,8 @@ if (typeof(require) !== 'undefined') {
 
     var das = require('./das');
     var DASSequence = das.DASSequence;
+    
+    var Promise = require('es6-promise').Promise;
 }
 
 function FetchPool() {


### PR DESCRIPTION
The promise is used in the kspace file, yet it isn't included as a require like the other files that use promise. This caused an error when loading with safari. The fix solved the issue I was seeing.
