### PR TITLE
missing variable formatLongInt in cbrowser

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -31,6 +31,7 @@ if (typeof(require) !== 'undefined') {
 
     var nf = require('./numformats');
     var formatQuantLabel = nf.formatQuantLabel;
+    var formatLongInt = nf.formatLongInt;
 
     var Chainset = require('./chainset').Chainset;
 


### PR DESCRIPTION
The formatLongInt was defined in browser-ui but not cbrowser. Errors in chrome when zooming.

ReferenceError: formatLongInt is not defined
    at Array.<anonymous> (http://localhost:8020/javascripts/dalliance.js:2866:76)
    at Browser.notifyLocation (http://localhost:8020/javascripts/dalliance.js:4490:36)
    at Browser.refresh (http://localhost:8020/javascripts/dalliance.js:3922:10)
    at Browser.zoom (http://localhost:8020/javascripts/dalliance.js:4087:10)
    at HTMLDivElement.<anonymous> (http://localhost:8020/javascripts/dalliance.js:2348:8)
    at thumbDragHandler (http://localhost:8020/javascripts/dalliance.js:20295:16)
