### PR TITLE
adding a new gulp compress target for minifying the created javascript

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,9 @@ var gconcat = require('gulp-concat');
 var closure = require('gulp-closure-compiler');
 var browserify = require('gulp-browserify');
 var rename = require('gulp-rename');
+var uglify = require('gulp-uglify');
+
+
 // var utils = require('gulp-util');
 // var gif = require('gulp-if');
 
@@ -15,7 +18,7 @@ gulp.task('build-worker', function() {
     nobuiltins: true
   }))
   .pipe(rename('worker-all.js'))
-  .pipe(gulp.dest('build/'));
+      .pipe(gulp.dest('build/'));
 });
 
 
@@ -69,3 +72,11 @@ gulp.task('watch', function() {
 
 gulp.task('default', ['build-main', 'build-worker']);
 gulp.task('compile', ['compile-main', 'compile-worker']);
+
+
+gulp.task('compress', function() {
+	gulp.src('build/*.js')
+	    .pipe(uglify())
+	    .pipe(gulp.dest('minified'))
+	    });
+


### PR DESCRIPTION
Hi,

The dalliance-all.js file currently has about 1.8M. This can be reduced to ~300k when minifying it, resulting in a faster download for users with slow bandwidth (mobile?). As such I created a new gulp target that automatically minifies everything in the build/ folder.

Andreas
