### PR TITLE
Using raw viewStart and viewEnd to improve unit base location tracking b...

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -229,10 +229,11 @@ Browser.prototype.realInit = function() {
     this.locSingleBase = makeElement('span', 'foo', {className: 'loc-single-base'});
     var locSingleBaseHolder = makeElement('div', this.locSingleBase,{className: 'loc-single-base-holder'}); 
     // Add listener to update single base location
-    this.addViewListener(function(chr, min, max) {
+    this.addViewListener(function(chr, minFloor, maxFloor, zoomSliderValue, zoomSliderDict, min, max) {
         // Just setting textContent causes layout flickering in Blink.
-        // This approach means that the element is never empty.
-        self.locSingleBase.appendChild(document.createTextNode(chr + ':' + formatLongInt((max + min)/2 + 1)));
+        // This approach means that the element is never empty.');
+        var loc = Math.round((max + min) / 2);
+        self.locSingleBase.appendChild(document.createTextNode(chr + ':' + formatLongInt(loc)));
         self.locSingleBase.removeChild(self.locSingleBase.firstChild);
     });
 
@@ -1872,7 +1873,9 @@ Browser.prototype.notifyLocation = function() {
                  alternate: (this.savedZoom+this.zoomMin) || this.zoomMin,
                  isSnapZooming: this.isSnapZooming,
                  min: this.zoomMin, 
-                 max: this.zoomMax});
+                 max: this.zoomMax},
+                 this.viewStart,
+                 this.viewEnd);
         } catch (ex) {
             console.log(ex.stack);
         }


### PR DESCRIPTION
...y adding these as two additional parameters provided to viewListeners.

I noticed some disagreement between unit base location and its corresponding advertisted location. The issue has been using min and max locations that have floored in notifyLocation. Added these as two new unfloored (fractional) parameters to preserve viewListeners API.
