### PR TITLE
make zoom changes register when going from full chromosome to 10 Mb range

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -1754,7 +1754,7 @@ Browser.prototype._setLocation = function(newChr, newMin, newMax, newChrInfo, ca
     this.viewEnd = newMax;
     var newScale = Math.max(this.featurePanelWidth, 50) / (this.viewEnd - this.viewStart);
     var oldScale = this.scale;
-    var scaleChanged = (Math.abs(newScale - oldScale)) > 0.0001;
+    var scaleChanged = (Math.abs(newScale - oldScale)) > 0.000001;
     this.scale = newScale;
 
     var newZS, oldZS;


### PR DESCRIPTION
When zooming from the entire chromosome range to a 10 Mb range, the tiers would not realise that the zoom level has changed. 
See: http://jsfiddle.net/zwy6bwrn/4/

and wait 10 seconds.

The scaleChanged variable was not registering the change in range.
