### PR TITLE
expose tier comparison. Used for complex tier management.

### DIFF
--- a/js/exports.js
+++ b/js/exports.js
@@ -14,6 +14,7 @@ var utils = require('./utils');
 var das = require('./das');
 
 window.Browser = browser.Browser;
+window.sourcesAreEqual = browser.sourcesAreEqual;
 window.Chainset = chainset.Chainset;    // Pre-0.12 configurations need this.
 
 // Useful for info plugins.  Should be reconsidered in the future.


### PR DESCRIPTION
Currently the code for comparing the dasSource of tiers is not public. This comparison is needed for more complex tier management, e.g. syncing tiers of multiple Dalliance browsers on the same screen.
