### PR TITLE
Send authorization in request for remote secure memstore files

### DIFF
--- a/js/memstore.js
+++ b/js/memstore.js
@@ -192,7 +192,9 @@ MemStoreFeatureSource.prototype._load = function(callback) {
         }
         r.readAsText(this.source.blob);
     } else {
-        textXHR(this.source.uri, callback, {});
+        if (this.source.credentials)
+            var opts = {credentials : this.source.credentials};
+        textXHR(this.source.uri, callback, opts);
     }
 }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -332,7 +332,7 @@ function saltURL(url) {
 }
 
 function textXHR(url, callback, opts) {
-    if (opts.salt) 
+    if (opts && opts.salt) 
         url = saltURL(url);
 
     var req = new XMLHttpRequest();


### PR DESCRIPTION
Noticed that remote bed files on a secure remote server was not getting the opts.credentials=true passed into js/utils.js textXHR.