### PR TITLE
Adding browser opts to specify ACGT/indel colors.

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -103,13 +103,6 @@ function Browser(opts) {
     this.tierBackgroundColors = ["rgb(245,245,245)", 'white'];
     this.minTierHeight = 20;
     this.noDefaultLabels = false;
-    this.baseColors = {
-        A: 'green', 
-        C: 'blue', 
-        G: 'orange', 
-        T: 'red',
-        '-' : 'hotpink' // deletion
-    };
 
     // Registry
 
@@ -132,6 +125,19 @@ function Browser(opts) {
     this.assemblyNameUcsc = true;
 
     this.initListeners = [];
+
+    if (opts.baseColors) {
+        this.baseColors = opts.baseColors
+    } else {
+        this.baseColors = {
+            A: 'green',
+            C: 'blue',
+            G: 'orange',
+            T: 'red',
+            '-' : 'hotpink', // deletion
+            'I' : 'red' // insertion
+        };
+    }
 
     if (opts.viewStart !== undefined && typeof(opts.viewStart) !== 'number') {
         throw Error('viewStart must be an integer');

--- a/js/feature-draw.js
+++ b/js/feature-draw.js
@@ -990,7 +990,7 @@ function glyphForFeature(feature, y, style, tier, forceHeight, noLabel)
                     }
                 } else if (co.op == 'I') {
                     var inseq =  rawseq.substr(cursor, co.cnt);
-                    var ig = new TriangleGlyph(minPos + (seq.length*scale), 5, 'S', 5, 'red');
+                    var ig = new TriangleGlyph(minPos + (seq.length*scale), 5, 'S', 5, tier.browser.baseColors['I']);
                     if (insertionLabels)
                         ig = new LabelledGlyph(GLOBAL_GC, ig, inseq, false, 'center', 'above', '7px sans-serif');
                     ig.feature = {label: 'Insertion: ' + inseq, type: 'insertion', method: 'insertion'};
@@ -1039,7 +1039,7 @@ function glyphForFeature(feature, y, style, tier, forceHeight, noLabel)
             gg = new GroupGlyph(indels);
         }
     } else if (gtype === '__INSERTION') {
-        var ig = new TriangleGlyph(minPos, 5, 'S', 5, 'red');
+        var ig = new TriangleGlyph(minPos, 5, 'S', 5, tier.browser.baseColors['I']);
         gg = new LabelledGlyph(GLOBAL_GC, ig, feature.insertion || feature.altAlleles[0], false, 'center', 'above', '7px sans-serif');
         if ((maxPos - minPos) > 1) {
             var fill = style.BGCOLOR || style.COLOR1 || 'green';


### PR DESCRIPTION
This pull request allows users to specify as a Browser option the colors to represent nucleotide bases as well as deletions and insertions. For example, 

```
var b = new Browser({
    ...
    baseColors: {
                    A: 'green', 
                    C: 'blue', 
                    G: 'orange', 
                    T: 'red',
                    '-' : 'black', // deletion
                    'I' : 'mediumpurple' // insertion
                },
    ...
});
```