### PR TITLE
Allow users to disable viewing base quality as alpha.

### DIFF
--- a/js/feature-draw.js
+++ b/js/feature-draw.js
@@ -1019,6 +1019,9 @@ function glyphForFeature(feature, y, style, tier, forceHeight, noLabel)
             strandColor = style._minusColor || 'lightskyblue';
         else
             strandColor = style._plusColor || 'lightsalmon';
+
+        if (style.__disableQuals)
+            quals = false;
         
         gg = new SequenceGlyph(
             tier.browser.baseColors, 

--- a/js/tier-edit.js
+++ b/js/tier-edit.js
@@ -323,7 +323,7 @@ Browser.prototype.openTierPanel = function(tier) {
                     seqInsertRow.style.display = 'table-row';
                     seqInsertToggle.checked =  isDasBooleanTrue(seqStyle.__INSERTIONS);
                     seqIgnoreQualsRow.style.display = 'table-row';
-                    seqIgnoreQualsToggle.checked = (seqStyle.__disableQuals === true);
+                    seqIgnoreQualsToggle.checked = (seqStyle.__disableQuals === undefined || seqStyle.__disableQuals === false);
                     console.log(seqStyle.__disableQuals);
                 } else {
                     seqMismatchRow.style.display = 'none';
@@ -375,7 +375,7 @@ Browser.prototype.openTierPanel = function(tier) {
         seqIgnoreQualsToggle.addEventListener('change', function(ev) {
             var nss = copyStylesheet(tier.stylesheet);
             var seqStyle = getSeqStyle(nss);
-            seqStyle.__disableQuals = seqIgnoreQualsToggle.checked;
+            seqStyle.__disableQuals = !seqIgnoreQualsToggle.checked;
             console.log(seqStyle.__disableQuals);
             tier.mergeStylesheet(nss);
         });

--- a/js/tier-edit.js
+++ b/js/tier-edit.js
@@ -322,9 +322,13 @@ Browser.prototype.openTierPanel = function(tier) {
                     seqMismatchToggle.checked = (seqStyle.__SEQCOLOR === 'mismatch');
                     seqInsertRow.style.display = 'table-row';
                     seqInsertToggle.checked =  isDasBooleanTrue(seqStyle.__INSERTIONS);
+                    seqIgnoreQualsRow.style.display = 'table-row';
+                    seqIgnoreQualsToggle.checked = (seqStyle.__disableQuals === true);
+                    console.log(seqStyle.__disableQuals);
                 } else {
                     seqMismatchRow.style.display = 'none';
                     seqInsertRow.style.display = 'none';
+                    seqIgnoreQualsRow.style.display = 'none';
                 }
 
                 if (seqStyle && seqMismatchToggle.checked && !isSimpleQuantitative) {
@@ -361,6 +365,18 @@ Browser.prototype.openTierPanel = function(tier) {
             var nss = copyStylesheet(tier.stylesheet);
             var seqStyle = getSeqStyle(nss);
             seqStyle.__INSERTIONS = seqInsertToggle.checked ? 'yes' : 'no';
+            tier.mergeStylesheet(nss);
+        });
+
+        var seqIgnoreQualsToggle = makeElement('input', null, {type: 'checkbox'});
+        var seqIgnoreQualsRow = makeElement('tr',
+            [makeElement('th', 'Reflect base quality as base color transparency'),
+             makeElement('td', seqIgnoreQualsToggle)]);
+        seqIgnoreQualsToggle.addEventListener('change', function(ev) {
+            var nss = copyStylesheet(tier.stylesheet);
+            var seqStyle = getSeqStyle(nss);
+            seqStyle.__disableQuals = seqIgnoreQualsToggle.checked;
+            console.log(seqStyle.__disableQuals);
             tier.mergeStylesheet(nss);
         });
 
@@ -417,7 +433,8 @@ Browser.prototype.openTierPanel = function(tier) {
             bumpRow,
             labelRow,
             seqMismatchRow,
-            seqInsertRow
+            seqInsertRow,
+            seqIgnoreQualsRow
              ]);
 
 


### PR DESCRIPTION
Allow users to disable dalliance from reflecting read base quality in base alpha transparency:

![image](https://cloud.githubusercontent.com/assets/4357962/6572455/4bb48892-c70a-11e4-8306-da7ac3b7d368.png)

![image](https://cloud.githubusercontent.com/assets/4357962/6572459/51ed595a-c70a-11e4-8661-c4175ecc4f47.png)