### PR TITLE
add clear functions to remove all tier listeners and features Loaded listeners

### DIFF
--- a/js/tier.js
+++ b/js/tier.js
@@ -581,6 +581,9 @@ DasTier.prototype.scheduleRedraw = function() {
         }, 10);
     }
 }
+DasTier.prototype.clearTierListeners = function() {
+	this.listeners = [];
+}
 
 
 DasTier.prototype.addTierListener = function(l) {
@@ -596,6 +599,10 @@ DasTier.prototype.notifyTierListeners = function(change) {
         }
     }
     this.browser.notifyTier();
+}
+
+DasTier.prototype.clearFeaturesLoadedListeners = function() {
+  this.featuresLoadedListeners = [];
 }
 
 DasTier.prototype.addFeaturesLoadedListener = function(handler) {


### PR DESCRIPTION
The tiers can add listeners, however they can not remove them. I added 2 functions to clear all the listeners.