### PR TITLE
Fix oom when invalid track

### DIFF
--- a/js/bigwig.js
+++ b/js/bigwig.js
@@ -766,9 +766,11 @@ function makeBwg(data, callback, name) {
         } else if (magic == BIG_BED_MAGIC) {
             bwg.type = 'bigbed';
         } else if (magic == BIG_WIG_MAGIC_BE || magic == BIG_BED_MAGIC_BE) {
-            callback(null, "Currently don't support big-endian BBI files");
+            return callback(null, "Currently don't support big-endian BBI files");
+            
         } else {
-            callback(null, "Not a supported format, magic=0x" + magic.toString(16));
+            return callback(null, "Not a supported format, magic=0x" + magic.toString(16));
+            
         }
 
         bwg.version = sa[2];             // 4

--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -1680,6 +1680,21 @@ Browser.prototype.removeTier = function(conf, force) {
     this.notifyTier();
 }
 
+Browser.prototype.removeAllTiers = function() {
+	var thisB = this;
+  this.selectedTiers = [];
+  this.markSelectedTiers();
+  this.tiers.forEach(function (targetTier) {
+	  targetTier.destroy();
+	  if (thisB.knownSpace) {
+	      thisB.knownSpace.featureCache[targetTier] = null;
+	  }
+  });
+  this.tiers.length = 0;
+  this.reorderTiers();
+  this.notifyTier();
+}
+
 Browser.prototype.getSequenceSource = function() {
     if (this._sequenceSource === undefined)
         this._sequenceSource = this._getSequenceSource();

--- a/js/sequence-draw.js
+++ b/js/sequence-draw.js
@@ -37,6 +37,9 @@ function tileSizeForScale(scale, min)
     if (!min) {
         min = MIN_TILE;
     }
+    if (scale < 0) {
+      scale = -scale;
+    }
 
     function ts(p) {
         return steps[p % steps.length] * Math.pow(10, (p / steps.length)|0);


### PR DESCRIPTION
When an invalid format was found, the error message in bigwig was not exiting the function, therefore there were cases that it tried to load bogus data, and would result in out of memory at 2 Gb