### PR TITLE
refactor tier data loading to support custom renders. #148

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -1216,7 +1216,7 @@ Browser.prototype.withPreservedSelection = function(f) {
 
 Browser.prototype.refreshTier = function(tier) {
     if (this.knownSpace) {
-        this.knownSpace.invalidate(tier);
+        this.knownSpace.invalidate(tier, defaultTierRenderer);
     }
 }
 
@@ -1323,6 +1323,19 @@ Browser.prototype.arrangeTiers = function() {
 }
 
 Browser.prototype.refresh = function() {
+
+    this.retrieveTierData(defaultTierRenderer);
+    this.drawOverlays();
+    this.positionRuler();
+
+};
+
+var defaultTierRenderer = function(status, tier) {
+    tier.draw();
+    tier.updateStatus(status);
+}
+
+Browser.prototype.retrieveTierData = function(tierRendererCallback) {
     this.notifyLocation();
     var width = (this.viewEnd - this.viewStart) + 1;
     var minExtraW = (100.0/this.scale)|0;
@@ -1363,9 +1376,7 @@ Browser.prototype.refresh = function() {
         this.drawnEnd = outerDrawnEnd;
     }
     
-    this.knownSpace.viewFeatures(this.chr, this.drawnStart, this.drawnEnd, scaledQuantRes);
-    this.drawOverlays();
-    this.positionRuler();
+    this.knownSpace.retrieveFeatures(this.chr, this.drawnStart, this.drawnEnd, scaledQuantRes, tierRendererCallback);
 }
 
 function setSources(msh, availableSources, maybeMapping) {
@@ -1616,18 +1627,18 @@ Browser.prototype.removeTier = function(conf, force) {
 }
 
 Browser.prototype.removeAllTiers = function() {
-  var thisB = this;
-  this.selectedTiers = [];
-  this.markSelectedTiers();
-  this.tiers.forEach(function (targetTier) {
-	  targetTier.destroy();
-	  if (thisB.knownSpace) {
-	      thisB.knownSpace.featureCache[targetTier] = null;
-	  }
-  });
-  this.tiers.length = 0;
-  this.reorderTiers();
-  this.notifyTier();
+	var thisB = this;
+    this.selectedTiers = [];
+    this.markSelectedTiers();
+    this.tiers.forEach(function (targetTier) {
+        targetTier.destroy();
+        if (thisB.knownSpace) {
+            thisB.knownSpace.featureCache[targetTier] = null;
+        }
+    });
+    this.tiers.length = 0;
+    this.reorderTiers();
+    this.notifyTier();
 }
 
 Browser.prototype.getSequenceSource = function() {

--- a/js/tier.js
+++ b/js/tier.js
@@ -260,20 +260,12 @@ DasTier.prototype.needsSequence = function(scale ) {
     return false;
 }
 
-DasTier.prototype.viewFeatures = function(chr, coverage, scale, features, sequence) {
+DasTier.prototype.setFeatures = function(chr, coverage, scale, features, sequence) {
     this.currentFeatures = features;
-    this.currentSequence = sequence;
-    this.notifyFeaturesLoaded();
-    
+    this.currentSequence = sequence;    
     this.knownChr = chr;
     this.knownCoverage = coverage;
-
-    if (this.status) {
-        this.status = null;
-        this._notifierToStatus();
-    }
-
-    this.draw();
+    this.notifyFeaturesLoaded();
 }
 
 DasTier.prototype.draw = function() {

--- a/js/tier.js
+++ b/js/tier.js
@@ -265,7 +265,10 @@ DasTier.prototype.setFeatures = function(chr, coverage, scale, features, sequenc
     this.currentSequence = sequence;    
     this.knownChr = chr;
     this.knownCoverage = coverage;
-    this.notifyFeaturesLoaded();
+    // only notify features loaded, if they are valid
+    if (features) {
+        this.notifyFeaturesLoaded();
+    }
 }
 
 DasTier.prototype.draw = function() {


### PR DESCRIPTION
allows for the tier data to be retrieved without rendering the default tiers. The default tiers can be rendered when needed by calling cbrowser.refresh(), which will use the cached data. updating the status and drawing the tier is now part of the default tier render method. Updating the tier height incase of exception was not needed as it was happening at the end of draw()->paint().