### PR TITLE
allow retrieve tier data to accept a subset of tiers

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -1324,7 +1324,7 @@ Browser.prototype.arrangeTiers = function() {
 
 Browser.prototype.refresh = function() {
 
-    this.retrieveTierData(defaultTierRenderer);
+    this.retrieveTierData(this.tiers, defaultTierRenderer);
     this.drawOverlays();
     this.positionRuler();
 
@@ -1335,7 +1335,7 @@ var defaultTierRenderer = function(status, tier) {
     tier.updateStatus(status);
 }
 
-Browser.prototype.retrieveTierData = function(tierRendererCallback) {
+Browser.prototype.retrieveTierData = function(tiers, tierRendererCallback) {
     this.notifyLocation();
     var width = (this.viewEnd - this.viewStart) + 1;
     var minExtraW = (100.0/this.scale)|0;
@@ -1345,12 +1345,12 @@ Browser.prototype.retrieveTierData = function(tierRendererCallback) {
     var oh = newOrigin - this.origin;
     this.origin = newOrigin;
     this.scaleAtLastRedraw = this.scale;
-    for (var t = 0; t < this.tiers.length; ++t) {
+    for (var t = 0; t < tiers.length; ++t) {
         var od = oh;
-        if (this.tiers[t].originHaxx) {
-            od += this.tiers[t].originHaxx;
+        if (tiers[t].originHaxx) {
+            od += tiers[t].originHaxx;
         }
-        this.tiers[t].originHaxx = od;
+        tiers[t].originHaxx = od;
     }
 
     var scaledQuantRes = this.targetQuantRes / this.scale;
@@ -1364,6 +1364,7 @@ Browser.prototype.retrieveTierData = function(tierRendererCallback) {
         var ss = this.getSequenceSource();
         if (this.knownSpace)
             this.knownSpace.cancel();
+        // known space is created based on the entire tier list, for future caching purposes, even if only a subset of the tiers are needed to be rendered now.
         this.knownSpace = new KnownSpace(this.tiers, this.chr, outerDrawnStart, outerDrawnEnd, scaledQuantRes, ss);
     }
     
@@ -1375,8 +1376,8 @@ Browser.prototype.retrieveTierData = function(tierRendererCallback) {
         this.drawnStart = outerDrawnStart;
         this.drawnEnd = outerDrawnEnd;
     }
-    
-    this.knownSpace.retrieveFeatures(this.chr, this.drawnStart, this.drawnEnd, scaledQuantRes, tierRendererCallback);
+    // send in the subset of tiers to retrieve.
+    this.knownSpace.retrieveFeatures(tiers, this.chr, this.drawnStart, this.drawnEnd, scaledQuantRes, tierRendererCallback);
 }
 
 function setSources(msh, availableSources, maybeMapping) {

--- a/js/kspace.js
+++ b/js/kspace.js
@@ -100,7 +100,7 @@ KnownSpace.prototype.bestCacheOverlapping = function(chr, min, max) {
     }
 }
 
-KnownSpace.prototype.retrieveFeatures = function(chr, min, max, scale, tierCallback) {
+KnownSpace.prototype.retrieveFeatures = function(tiers, chr, min, max, scale, tierCallback) {
     if (scale != scale) {
         throw "retrieveFeatures called with silly scale";
     }
@@ -124,7 +124,7 @@ KnownSpace.prototype.retrieveFeatures = function(chr, min, max, scale, tierCallb
     this.seqWasFetched = false;
     this.viewCount++;
     
-    this.startFetchesForTiers(this.tierMap, tierCallback);
+    this.startFetchesForTiers(tiers, tierCallback);
     this.pool.notifyRequestsIssued();
 }
     


### PR DESCRIPTION
Allows for a  subset of tiers to be retrieved. If the known space is not created yet, then the whole tier list is sent to known space constructor, this is so future requests to known space do not need to worry about if the tier has been initialised for caching purposes.

The default refresh() sends in the whole list of tiers to retrieve. This fix allows for fast retrieval of specific tiers. 