### PR TITLE
Add port number to prefix, if relevant

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -165,7 +165,11 @@ function Browser(opts) {
     // If the prefix only starts with a single '/' this is relative to the current
     // site, so we need to prefix the prefix with //{hostname}
     if (this.prefix.indexOf('//') < 0 && this.prefix.indexOf('/') === 0) {
-        this.prefix = '//'+window.location.hostname+this.prefix;
+        var location = window.location.hostname;
+        if (window.location.port) {
+            location += ':' + window.location.port
+        };
+        this.prefix = '//' + location + this.prefix;
     }
     if (this.prefix.indexOf('//') === 0) {
         var proto = window.location.protocol;


### PR DESCRIPTION
If a Dalliance genome browser is being tested (or hosted) on a port other than 80 and `prefix` is specified, resources fail to load because the resolved URLs lack the port number.

I've updated `cbrowser.js` such that if `window.location.port` exists, it gets incorporated into `this.prefix`. Now everything works for me regardless of port.