### PR TITLE
Only call init listeners after the location has been set.

### DIFF
--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -355,7 +355,7 @@ Browser.prototype.realInit2 = function() {
     removeChildren(this.tierHolder);
     removeChildren(this.pinnedTierHolder);
 
-    this.featurePanelWidth = this.tierHolder.getBoundingClientRect().width | self.offscreenInitWidth | 0;
+    this.featurePanelWidth = this.tierHolder.getBoundingClientRect().width | thisB.offscreenInitWidth | 0;
     this.scale = this.featurePanelWidth / (this.viewEnd - this.viewStart);
     if (!this.zoomMax) {
         this.zoomMax = this.zoomExpt * Math.log(this.maxViewWidth / this.zoomBase);
@@ -716,9 +716,6 @@ Browser.prototype.realInit2 = function() {
     thisB._ensureTiersGrouped();
     thisB.arrangeTiers();
     thisB.reorderTiers();
-    thisB.setLocation(this.chr, this.viewStart, this.viewEnd, function () {
-        thisB.setSelectedTier(1);
-    });
 
 
     var ss = this.getSequenceSource();
@@ -773,14 +770,17 @@ Browser.prototype.realInit2 = function() {
         this.storeStatus();
     }
 
-    // Ping any init listeners.
-    for (var ii = 0; ii < this.initListeners.length; ++ii) {
-        try {
-            this.initListeners[ii].call(this);
-        } catch (e) {
-            console.log(e);
+    thisB.setLocation(this.chr, this.viewStart, this.viewEnd, function () {
+        thisB.setSelectedTier(1);
+        // Ping any init listeners.
+        for (var ii = 0; ii < thisB.initListeners.length; ++ii) {
+            try {
+                thisB.initListeners[ii].call(thisB);
+            } catch (e) {
+                console.log(e);
+            }
         }
-    }
+    });
 }
 
 // 


### PR DESCRIPTION
Init listener needs to only be called when the sequence source is loaded and setLocation has been called. Otherwise, while dalliance is initialising and retrieving the
sequence source, the init listeners may have already triggered. The
application may then try to render which uses known space, however, then
the original setLocation occurs (that was waiting for the Sequence
Source), which calls cancel on the existing known space operation, as it
tries to render again (as setLocation renders currently).