### PR TITLE
Add option to scale vertically for sequence tiers

### DIFF
--- a/js/feature-draw.js
+++ b/js/feature-draw.js
@@ -113,6 +113,11 @@ function drawFeatureTier(tier)
         tier.padding = tier.dasSource.padding;
     else
         tier.padding = MIN_PADDING;
+    
+    if (typeof(tier.dasSource.scaleVertical) === 'boolean')
+        tier.scaleVertical = tier.dasSource.scaleVertical;
+    else
+        tier.scaleVertical = false;
 
     var glyphs = [];
     var specials = false;
@@ -486,8 +491,14 @@ DasTier.prototype.paintToContext = function(gc, oc, offset) {
                 }
             }
         }
-        gc.translate(0, subtiers[s].height + this.padding);
-        oc.translate(0, subtiers[s].height + this.padding);
+        if (this.scaleVertical) {
+            var scale = this.browser.scale;
+            gc.translate(0, scale + this.padding);
+            oc.translate(0, scale + this.padding);
+        } else {
+            gc.translate(0, subtiers[s].height + this.padding);
+            oc.translate(0, subtiers[s].height + this.padding);
+        }
     }
     gc.restore();
 

--- a/js/feature-draw.js
+++ b/js/feature-draw.js
@@ -1041,7 +1041,8 @@ function glyphForFeature(feature, y, style, tier, forceHeight, noLabel)
             refSeq, 
             style.__SEQCOLOR, 
             quals,
-            !isDasBooleanTrue(style.__CLEARBG)
+            !isDasBooleanTrue(style.__CLEARBG),
+            tier.scaleVertical
         );
         if (insertionLabels)
             gg = new TranslatedGlyph(gg, 0, 7);

--- a/js/glyphs.js
+++ b/js/glyphs.js
@@ -1152,7 +1152,7 @@ var isCloseUp = function(scale) {
     return scale >= 8;
 }
 
-function SequenceGlyph(baseColors, strandColor, min, max, height, seq, ref, scheme, quals, fillbg) {
+function SequenceGlyph(baseColors, strandColor, min, max, height, seq, ref, scheme, quals, fillbg, scaleVertical) {
     this.baseColors = baseColors;
     this._strandColor = strandColor;
     this._min = min;
@@ -1163,6 +1163,7 @@ function SequenceGlyph(baseColors, strandColor, min, max, height, seq, ref, sche
     this._scheme = scheme;
     this._quals = quals;
     this._fillbg = fillbg;
+    this._scaleVertical = scaleVertical;
 }
 
 SequenceGlyph.prototype.min = function() {return this._min};
@@ -1185,9 +1186,13 @@ SequenceGlyph.prototype.draw = function(gc) {
 
     if (mismatch && !isCloseUp(scale)) {
         gc.fillStyle = this._strandColor;
-        gc.fillRect(this._min, this._height/4, this._max - this._min, this._height/2);
+        if (this._scaleVertical)
+            gc.fillRect(this._min, scale, this._max - this._min, scale);
+        else
+            gc.fillRect(this._min, this._height/4, this._max - this._min, this._height/2);
     }
 
+    
     for (var p = 0; p < seqLength; ++p) {
         var base = seq ? seq.substr(p, 1).toUpperCase() : 'N';
         
@@ -1216,9 +1221,12 @@ SequenceGlyph.prototype.draw = function(gc) {
         gc.fillStyle = color;
 
         var alt = altPattern.test(base);
-        if (this._fillbg || !isCloseUp(scale) || !alt)
-            gc.fillRect(this._min + p*scale, 0, scale, this._height);
-
+        if (this._fillbg || !isCloseUp(scale) || !alt) {
+            if (this._scaleVertical)
+                gc.fillRect(this._min + p*scale, scale, scale, scale);
+            else
+                gc.fillRect(this._min + p*scale, 0, scale, this._height);
+        }
         if (isCloseUp(scale) && alt) {
             var key = color + '_' + base
             var img = __dalliance_SequenceGlyphCache[key];
@@ -1240,10 +1248,11 @@ SequenceGlyph.prototype.draw = function(gc) {
                 imgGc.fillText(base, 0.5 * (8.0 - w), 8);
                 __dalliance_SequenceGlyphCache[key] = img;
             }
+            var dy = this._scaleVertical ? scale : 0;
             if (isRetina)
-                gc.drawImage(img, this._min + p*scale + 0.5*(scale-8), 0, 8, 10);
+                gc.drawImage(img, this._min + p*scale + 0.5*(scale-8), dy, 8, 10);
             else
-                gc.drawImage(img, this._min + p*scale + 0.5*(scale-8), 0);
+                gc.drawImage(img, this._min + p*scale + 0.5*(scale-8), dy);
         } 
 
         if (this._quals) {


### PR DESCRIPTION
As a user zooms in/out the vertical axis is scaled accordingly (presently dalliance scales only on the horizontal axis). This allows locations with particularly high depth to fit the height of the screen.

To enable this option set `scaleVertical: true` in the source config.
