### PR TITLE
Add missing js files into hubstub HEAD

### DIFF
--- a/hubstub.html
+++ b/hubstub.html
@@ -59,6 +59,9 @@
 <script language="javascript" src="js/svg-utils.js"></script>
 <script language="javascript" src="js/numformats.js"></script>
 <script language="javascript" src="js/cigar.js"></script>
+<script language="javascript" src="js/zoomslider.js"></script>
+<script language="javascript" src="js/style.js"></script>
+<script language="javascript" src="js/sourcecompare.js"></script>
 
 
 


### PR DESCRIPTION
There appear to be a few JS files not included in the <head> section of hubstub.html that are required