### PR TITLE
pre-parsed features and other things I like

### DIFF
--- a/css/dalliance-scoped.css
+++ b/css/dalliance-scoped.css
@@ -29,7 +29,7 @@
   display: -webkit-inline-flex;
   flex-direction: column;
   -webkit-flex-direction: column;
-  max-height: 500px;
+  max-height: 1000px;
   width: 100%;
   outline: none;
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+    browser: require('./js/cbrowser').Browser,
+    chainset: require('./js/chainset').Chainset,
+    sourcesAreEqual: require('./js/sourcecompare').sourcesAreEqual,
+    makeElement: require('./js/utils').makeElement
+};

--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -146,14 +146,39 @@ function Browser(opts) {
     if (opts.baseColors) {
         this.baseColors = opts.baseColors
     } else {
-        this.baseColors = {
-            A: 'green',
-            C: 'blue',
-            G: 'orange',
-            T: 'red',
-            '-' : 'hotpink', // deletion
-            'I' : 'red' // insertion
-        };
+        if (opts.aminoAcids) {
+            this.baseColors = {
+                F: 'rgb(182, 201, 237)',
+                L: 'rgb(213, 236, 213)',
+                I: 'rgb(239, 213, 211)',
+                M: 'rgb(255, 23, 0)',
+                V: 'rgb(255, 172, 0)',
+                S: 'rgb(255, 244, 19)',
+                P: 'rgb(138, 189, 67)',
+                T: 'rgb(36, 153, 57)',
+                A: 'rgb(0, 166, 236)',
+                Y: 'rgb(0, 101, 178)',
+                H: 'rgb(215, 206, 182)',
+                Q: 'rgb(252, 176, 124)',
+                N: 'rgb(159, 148, 186)',
+                K: 'rgb(133, 117, 67)',
+                D: 'rgb(108, 242, 51)',
+                E: 'rgb(0, 253, 255)',
+                C: 'rgb(248, 129, 51)',
+                W: 'rgb(243, 68, 252)',
+                R: 'rgb(207, 207, 207)',
+                G: 'rgb(166, 213, 227)'
+            };
+        } else {
+            this.baseColors = {
+                A: 'green',
+                C: 'blue',
+                G: 'orange',
+                T: 'red',
+                '-' : 'hotpink', // deletion
+                'I' : 'red' // insertion
+            };
+        }
     }
 
     if (opts.viewStart !== undefined && typeof(opts.viewStart) !== 'number') {
@@ -2523,6 +2548,7 @@ if (typeof(module) !== 'undefined') {
     var sa = require('./sourceadapters');
     var TwoBitSequenceSource = sa.TwoBitSequenceSource;
     var EnsemblSequenceSource = sa.EnsemblSequenceSource;
+    var EnsemblProteinSequenceSource = sa.EnsemblProteinSequenceSource;
     var DASSequenceSource = sa.DASSequenceSource;
 
     var KnownSpace = require('./kspace').KnownSpace;

--- a/js/sourceadapters.js
+++ b/js/sourceadapters.js
@@ -108,7 +108,11 @@ Browser.prototype.createSources = function(config) {
         if (config.twoBitURI || config.twoBitBlob) {
             ss = new TwoBitSequenceSource(config);
         } else if (config.ensemblURI) {
-            ss = new EnsemblSequenceSource(config);
+            if (config.aminoAcids) {
+                ss = new EnsemblProteinSequenceSource(config);
+            } else {
+                ss = new EnsemblSequenceSource(config);
+            }
         } else {
             ss = new DASSequenceSource(config);
         }
@@ -591,8 +595,6 @@ TwoBitSequenceSource.prototype.getSeqInfo = function(chr, cnt) {
 
 function EnsemblSequenceSource(source) {
   this.source = source;
-  // http://data.gramene.org/ensembl/info/assembly/triticum_aestivum/2B?content-type=application/json
-  // http://data.gramene.org/ensembl/sequence/region/triticum_aestivum/2B:8001..18000:1?content-type=application/json
 }
 
 EnsemblSequenceSource.prototype.fetch = function(chr, min, max, pool, callback) {
@@ -633,6 +635,55 @@ EnsemblSequenceSource.prototype.getSeqInfo = function(chr, cnt) {
       } else {
   		  var jr = JSON.parse(req.response);
         cnt(jr);
+      }
+    }
+  }
+  req.open('GET', url, true);
+  req.responseType = 'text';
+  req.send('');
+}
+
+function EnsemblProteinSequenceSource(source) {
+  this.source = source;
+}
+
+EnsemblProteinSequenceSource.prototype.fetch = function(chr, min, max, pool, callback) {
+  var url = this.source.ensemblURI + '/sequence/id/' + chr + '?type=protein&content-type=application/json';
+  var req = new XMLHttpRequest();
+  req.onreadystatechange = function() {
+  	if (req.readyState == 4) {
+	    if (req.status >= 300) {
+        var err = 'Error code ' + req.status;
+        try {
+          var jr = JSON.parse(req.response);
+          if (jr.error) {
+            err = jr.error;
+          }
+        } catch (ex) {};
+
+		    callback(err, null);
+	    } else {
+    		var jr = JSON.parse(req.response);
+        var sequence = new DASSequence(chr, 1, jr.seq.length + 1, 'PEP', jr.seq);
+        return callback(null, sequence);
+      }
+    }
+  }
+  req.open('GET', url, true);
+  req.responseType = 'text';
+  req.send('');
+}
+
+EnsemblProteinSequenceSource.prototype.getSeqInfo = function(chr, cnt) {
+  var url = this.source.ensemblURI + '/sequence/id/' + chr + '?type=protein&content-type=application/json';
+  var req = new XMLHttpRequest();
+  req.onreadystatechange = function() {
+	  if (req.readyState == 4) {
+      if (req.status >= 300) {
+	      cnt();
+      } else {
+  		  var jr = JSON.parse(req.response);
+        cnt({length:jr.seq.length});
       }
     }
   }
@@ -1740,6 +1791,7 @@ if (typeof(module) !== 'undefined') {
 
         TwoBitSequenceSource: TwoBitSequenceSource,
         EnsemblSequenceSource: EnsemblSequenceSource,
+        EnsemblProteinSequenceSource: EnsemblProteinSequenceSource,
         DASSequenceSource: DASSequenceSource,
         MappedFeatureSource: MappedFeatureSource,
         CachingFeatureSource: CachingFeatureSource,

--- a/js/vcf.js
+++ b/js/vcf.js
@@ -18,6 +18,8 @@ if (typeof(require) !== 'undefined') {
     var DASStyle = das.DASStyle;
     var DASFeature = das.DASFeature;
     var DASGroup = das.DASGroup;
+
+    var revalidator = require('revalidator');
 }
 
 function VCFParser() {
@@ -105,6 +107,68 @@ VCFParseSession.prototype.parse = function(line) {
 }
 
 VCFParseSession.prototype.flush = function() {};
+
+VCFParseSession.prototype.schema = {
+  properties: {
+    segment: {
+      description: 'the name of the region containing the variation',
+      type: 'string',
+      required: true
+    },
+    min: {
+      description: 'the start position',
+      type: 'integer',
+      minimum: 1,
+      required: true
+    },
+    max: {
+      description: 'the end position',
+      type: 'integer',
+      required: true
+    },
+    id: {
+      description: 'identifier of variant',
+      type: 'string',
+      required: true
+    },
+    refAllele: {
+      description: 'reference allele',
+      type: 'string',
+      required: true
+    },
+    altAlleles: {
+      description: 'list of alternate alleles',
+      type: 'array',
+      items: { type: 'string' },
+      required: true
+    },
+    info: {
+      description: 'info',
+      type: 'object',
+      required: true
+    },
+    type: {
+      description: 'type of variation',
+      type: 'string',
+      enum: ['insertion','deletion','substitution'],
+      required: true
+    },
+    insertion: {
+      description: 'the actual insertion',
+      type: 'string'
+    }
+  }
+};
+
+VCFParseSession.prototype.validate = function(f) {
+  // use revalidator.validate to check if feature f is valid
+  var check = revalidator.validate(f, this.schema);
+  if (check.valid) {
+    this.sink(f);
+  } else {
+    console.log(check.errors);
+  }
+}
 
 VCFParser.prototype.getStyleSheet = function(callback) {
     var stylesheet = new DASStylesheet();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.13.0",
   "description": "Fast, embeddable genome visualization",
   "homepage": "https://www.biodalliance.org/",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:dasmoth/dalliance.git"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-rename": "~1.2.0",
     "watchify": "~0.8.3",
     "karma-bro": "~0.2.2",
-    "closure-compiler": "~0.2.6"
+    "closure-compiler": "~0.2.6",
+    "revalidator": "~0.3.1"
   }
 }


### PR DESCRIPTION
This pull request modifies memstore to accept pre-parsed bed, wig, vcf data provided they validate against a corresponding schema. This resolves #174 but also includes other things that I have been using (for React integration and having a protein sequence source from the ensembl rest API). I'm not sure if you would like to include some/all of these changes.