### PR TITLE
Fix IE10/11 XmlHttpRequest exception

### DIFF
--- a/js/das.js
+++ b/js/das.js
@@ -756,7 +756,6 @@ function doCrossDomainRequest(url, handler, credentials, custAuth) {
                 5000
             );
 
-            req.timeout = 5000;
             req.ontimeout = function() {
                 console.log('timeout on ' + url);
             };
@@ -770,6 +769,9 @@ function doCrossDomainRequest(url, handler, credentials, custAuth) {
                 }
             };
             req.open("get", url, true);
+            // IE10/11 fix: The timeout property may be set only in the time interval between a call to the open method
+            //              and the first call to the send method.
+            req.timeout = 5000;
             if (credentials) {
                 req.withCredentials = true;
             }


### PR DESCRIPTION
doCrossDomainRequest fails in IE10/11 because req.timeout is specified before req.open resulting in various genome browser resource loading errors (e.g. loading a DAS track).

See: https://msdn.microsoft.com/en-us/library/cc304105(v=vs.85).aspx