### PR TITLE
Configuration option to disable "Bumping Limit Exceeded" warning

### DIFF
--- a/js/feature-draw.js
+++ b/js/feature-draw.js
@@ -356,7 +356,7 @@ function drawFeatureTier(tier)
     tier.subtiers = bumpedSTs;
     tier.glyphCacheOrigin = tier.browser.viewStart;
 
-    if (subtiersExceeded)
+    if (subtiersExceeded && !tier.browser.noBumpWarning)
         tier.updateStatus('Bumping limit exceeded, use the track editor to see more features');
     else
         tier.updateStatus();


### PR DESCRIPTION
While the "bumping limit exceeded warning" may be viewed as mandatory ( #145 ), for some use cases (e.g. targeted sequencing), higher coverage than is practical to load is the norm. In these contexts, the warning is unnecessary and gets in the way. I don't at all propose removing the warning, but I think providing an option to disable it would be a good compromise.

The IGV viewer also has a limit (they use the term "downsampling") and it does not warn users of this (see http://www.broadinstitute.org/igv/Preferences#Alignments).