### PR TITLE
Fix css

### DIFF
--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -57,7 +57,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     holder.classList.add('dalliance');
-    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar'});
+    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar row'});
 
     var title = b.coordSystem.speciesName + ' ' + b.nameForCoordSystem(b.coordSystem);
     if (this.setDocumentTitle) {
@@ -66,7 +66,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     var locField = makeElement('input', '', {className: 'loc-field'});
     b.makeTooltip(locField, 'Enter a genomic location or gene name');
-    var locStatusField = makeElement('p', '', {className: 'loc-status'});
+    var locStatusField = makeElement('p', '', {className: 'loc-status col-2'});
 
     var zoomInBtn = makeElement('a', [makeElement('i', null, {className: 'fa fa-search-plus'})], {className: 'btn'});
     var zoomSlider = new makeZoomSlider({width: b.zoomSliderWidth});
@@ -86,10 +86,10 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var tierEditButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-road'})], {className: 'btn'});
     b.makeTooltip(tierEditButton, 'Configure currently selected track(s) (E)')
 
-    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
-    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
+    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn ml-3'}, {width: '5px'});
+    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right mr-3'}, {width: '5px'});
 
-    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right'});
+    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)
         modeButtons.appendChild(addTrackBtn);
     if (!this.noTrackEditor)
@@ -113,26 +113,30 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     if (!this.noLeapButtons)
-        toolbar.appendChild(leapRightButton);
-
-    if (modeButtons.firstChild)
-        toolbar.appendChild(modeButtons);
-    
-    if (!this.noLeapButtons)
         toolbar.appendChild(leapLeftButton);
+
     if (!this.noTitle) {
         toolbar.appendChild(makeElement('div', makeElement('h4', title, {}, {margin: '0px'}), {className: 'btn-group title'}));
     }
+
     if (!this.noLocationField)
         toolbar.appendChild(makeElement('div', [locField, locStatusField], {className: 'btn-group loc-group'}));
+
     if (!this.noClearHighlightsButton)
         toolbar.appendChild(clearHighlightsButton);
 
     if (!this.noZoomSlider) {
         toolbar.appendChild(makeElement('div', [zoomInBtn,
-                                                makeElement('span', zoomSlider, {className: 'btn'}),
+                                                makeElement('span', zoomSlider, {className: 'btn ml'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
+
+    if (modeButtons.firstChild)
+        toolbar.appendChild(modeButtons);
+    
+    if (!this.noLeapButtons)
+        toolbar.appendChild(leapRightButton);
+    
     
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);

--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -57,7 +57,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     holder.classList.add('dalliance');
-    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar'});
+    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar row'});
 
     var title = b.coordSystem.speciesName + ' ' + b.nameForCoordSystem(b.coordSystem);
     if (this.setDocumentTitle) {
@@ -66,7 +66,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     var locField = makeElement('input', '', {className: 'loc-field'});
     b.makeTooltip(locField, 'Enter a genomic location or gene name');
-    var locStatusField = makeElement('p', '', {className: 'loc-status'});
+    var locStatusField = makeElement('p', '', {className: 'loc-status col-2'});
 
     var zoomInBtn = makeElement('a', [makeElement('i', null, {className: 'fa fa-search-plus'})], {className: 'btn'});
     var zoomSlider = new makeZoomSlider({width: b.zoomSliderWidth});
@@ -89,7 +89,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
     var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
 
-    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right'});
+    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)
         modeButtons.appendChild(addTrackBtn);
     if (!this.noTrackEditor)
@@ -113,18 +113,15 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     if (!this.noLeapButtons)
-        toolbar.appendChild(leapRightButton);
-
-    if (modeButtons.firstChild)
-        toolbar.appendChild(modeButtons);
-    
-    if (!this.noLeapButtons)
         toolbar.appendChild(leapLeftButton);
+
     if (!this.noTitle) {
         toolbar.appendChild(makeElement('div', makeElement('h4', title, {}, {margin: '0px'}), {className: 'btn-group title'}));
     }
+
     if (!this.noLocationField)
         toolbar.appendChild(makeElement('div', [locField, locStatusField], {className: 'btn-group loc-group'}));
+
     if (!this.noClearHighlightsButton)
         toolbar.appendChild(clearHighlightsButton);
 
@@ -133,6 +130,12 @@ Browser.prototype.initUI = function(holder, genomePanel) {
                                                 makeElement('span', zoomSlider, {className: 'btn'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
+
+    if (modeButtons.firstChild)
+        toolbar.appendChild(modeButtons);
+
+    if (!this.noLeapButtons)
+        toolbar.appendChild(leapRightButton);
     
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);

--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -57,7 +57,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     holder.classList.add('dalliance');
-    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar row'});
+    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar'});
 
     var title = b.coordSystem.speciesName + ' ' + b.nameForCoordSystem(b.coordSystem);
     if (this.setDocumentTitle) {
@@ -66,7 +66,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     var locField = makeElement('input', '', {className: 'loc-field'});
     b.makeTooltip(locField, 'Enter a genomic location or gene name');
-    var locStatusField = makeElement('p', '', {className: 'loc-status col-2'});
+    var locStatusField = makeElement('p', '', {className: 'loc-status'});
 
     var zoomInBtn = makeElement('a', [makeElement('i', null, {className: 'fa fa-search-plus'})], {className: 'btn'});
     var zoomSlider = new makeZoomSlider({width: b.zoomSliderWidth});
@@ -89,7 +89,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
     var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
 
-    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
+    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right'});
     if (!this.noTrackAdder)
         modeButtons.appendChild(addTrackBtn);
     if (!this.noTrackEditor)
@@ -113,15 +113,18 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     if (!this.noLeapButtons)
-        toolbar.appendChild(leapLeftButton);
+        toolbar.appendChild(leapRightButton);
 
+    if (modeButtons.firstChild)
+        toolbar.appendChild(modeButtons);
+    
+    if (!this.noLeapButtons)
+        toolbar.appendChild(leapLeftButton);
     if (!this.noTitle) {
         toolbar.appendChild(makeElement('div', makeElement('h4', title, {}, {margin: '0px'}), {className: 'btn-group title'}));
     }
-
     if (!this.noLocationField)
         toolbar.appendChild(makeElement('div', [locField, locStatusField], {className: 'btn-group loc-group'}));
-
     if (!this.noClearHighlightsButton)
         toolbar.appendChild(clearHighlightsButton);
 
@@ -130,12 +133,6 @@ Browser.prototype.initUI = function(holder, genomePanel) {
                                                 makeElement('span', zoomSlider, {className: 'btn'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
-
-    if (modeButtons.firstChild)
-        toolbar.appendChild(modeButtons);
-
-    if (!this.noLeapButtons)
-        toolbar.appendChild(leapRightButton);
     
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);

--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -86,8 +86,8 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var tierEditButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-road'})], {className: 'btn'});
     b.makeTooltip(tierEditButton, 'Configure currently selected track(s) (E)')
 
-    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn ml-3'}, {width: '5px'});
-    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right mr-3'}, {width: '5px'});
+    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
+    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
 
     var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)

--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -86,8 +86,8 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var tierEditButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-road'})], {className: 'btn'});
     b.makeTooltip(tierEditButton, 'Configure currently selected track(s) (E)')
 
-    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
-    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
+    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn ml-3'}, {width: '5px'});
+    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right mr-3'}, {width: '5px'});
 
     var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)

--- a/js/version.js
+++ b/js/version.js
@@ -14,7 +14,7 @@ var VERSION = {
     MAJOR:  0,
     MINOR:  13,
     MICRO:  7,
-    BRANCH: 'dev'
+    BRANCH: 'Helix-dev'
 };
 
 VERSION.toString = function() {

--- a/js/version.js
+++ b/js/version.js
@@ -14,7 +14,7 @@ var VERSION = {
     MAJOR:  0,
     MINOR:  13,
     MICRO:  7,
-    BRANCH: 'Helix-dev'
+    BRANCH: 'dev'
 };
 
 VERSION.toString = function() {


### PR DESCRIPTION
# What this PR does

Fixes the css of the toolbar buttons and changes the version from dev to Helix-dev.

pull-right and pull-left no longer work in bootstrap 4 so the buttons had to be added in the correct order instead of relying on these classes. The browser should be backwards compatible with bootstrap 2 though this was not explicitly tested.