### PR TITLE
Add disableFeaturePopupDrag option

### DIFF
--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -52,7 +52,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     if (!b.disableDefaultFeaturePopup) {
         this.addFeatureListener(function(ev, feature, hit, tier) {
-            b.featurePopup(ev, feature, hit, tier);
+            b.featurePopup(ev, feature, hit, tier, { disableDrag: b.disableFeaturePopupDrag });
         });
     }
 
@@ -117,7 +117,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     if (modeButtons.firstChild)
         toolbar.appendChild(modeButtons);
-    
+
     if (!this.noLeapButtons)
         toolbar.appendChild(leapLeftButton);
     if (!this.noTitle) {
@@ -133,7 +133,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
                                                 makeElement('span', zoomSlider, {className: 'btn'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
-    
+
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);
         holder.appendChild(toolbar);
@@ -147,7 +147,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var lt5 = Math.log(5) / Math.log(10);
     var roundSliderValue = function(x) {
         var ltx = (x / b.zoomExpt + Math.log(b.zoomBase)) / Math.log(10);
-        
+
         var whole = ltx|0
         var frac = ltx - whole;
         var rounded
@@ -198,7 +198,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
         var zmax = zoom.max;
         var zrange = zmax - zmin;
 
-        
+
         var numSliderTicks = 4;
         if (b.zoomSliderWidth && b.zoomSliderWidth < 150)
             numSliderTicks = 3;
@@ -243,7 +243,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
             });
         }
     }, false);
-    
+
     var trackAddPopup;
     addTrackBtn.addEventListener('click', function(ev) {
         b.showTrackAdder(ev);
@@ -503,8 +503,8 @@ Browser.prototype.toggleOptsPopup = function(ev) {
             b.storeStatus();
         }, false);
         optsTable.appendChild(makeElement('tr', [makeElement('td', 'Vertical guideline', {align: 'right'}), makeElement('td', rulerSelect)]));
-        
-        var singleBaseHighlightButton = makeElement('input', '', {type: 'checkbox', checked: b.singleBaseHighlight}); 
+
+        var singleBaseHighlightButton = makeElement('input', '', {type: 'checkbox', checked: b.singleBaseHighlight});
         singleBaseHighlightButton.addEventListener('change', function(ev) {
             b.singleBaseHighlight = singleBaseHighlightButton.checked;
             b.positionRuler();
@@ -512,7 +512,7 @@ Browser.prototype.toggleOptsPopup = function(ev) {
         }, false);
         singleBaseHighlightButton.setAttribute('id','singleBaseHightlightButton'); // making this because access is required when the key 'u' is pressed and the options are visible
         optsTable.appendChild(makeElement('tr', [makeElement('td', 'Display and highlight current genome location', {align: 'right'}), makeElement('td', singleBaseHighlightButton)]));
-        
+
         optsForm.appendChild(optsTable);
 
         var resetButton = makeElement('button', 'Reset browser', {className: 'btn'}, {marginLeft: 'auto', marginRight: 'auto', display: 'block'});

--- a/js/cbrowser.js
+++ b/js/cbrowser.js
@@ -116,7 +116,7 @@ function Browser(opts) {
 
     this.minExtraWidth = 100.0;
     this.maxExtraWidth = 1000.0;
-    
+
     // Options.
 
     this.reverseScrolling = false;
@@ -135,6 +135,7 @@ function Browser(opts) {
     this.tierBackgroundColors = ["rgb(245,245,245)", 'white'];
     this.minTierHeight = 20;
     this.noDefaultLabels = false;
+    this.disableFeaturePopupDrag = opts.disableFeaturePopupDrag;
 
     // Registry
 
@@ -200,7 +201,7 @@ function Browser(opts) {
     for (var k in opts) {
         this[k] = opts[k];
     }
-    
+
     if (typeof(opts.uiPrefix) === 'string' && typeof(opts.prefix) !== 'string') {
         this.prefix = opts.uiPrefix;
     }
@@ -304,7 +305,7 @@ Browser.prototype.realInit = function() {
             throw Error('pageName must be a valid element ID (or use the injectionPoint option instead)');
         }
     }
-    
+
     this.browserHolderHolder.classList.add('dalliance-injection-point');
     this.browserHolder = makeElement('div', null, {className: 'dalliance dalliance-root', tabIndex: -1});
     if (this.maxHeight) {

--- a/js/domui.js
+++ b/js/domui.js
@@ -92,34 +92,35 @@ Browser.prototype.popit = function(ev, name, ele, opts)
         }, false);
         var tbar = makeElement('h4', [makeElement('span', name, null, {maxWidth: '200px'}), closeButton], {/*className: 'popover-title' */}, {paddingLeft: '10px', paddingRight: '10px'});
 
-        var dragOX, dragOY;
-        var moveHandler, upHandler;
-        moveHandler = function(ev) {
-            ev.stopPropagation(); ev.preventDefault();
-            left = left + (ev.clientX - dragOX);
-            if (left < 8) {
-                left = 8;
-            } if (left > (winWidth - width - 32)) {
-                left = (winWidth - width - 26);
+        if ( !opts.disableDrag ) {
+            var dragOX, dragOY;
+            var moveHandler, upHandler;
+            moveHandler = function(ev) {
+                ev.stopPropagation(); ev.preventDefault();
+                left = left + (ev.clientX - dragOX);
+                if (left < 8) {
+                    left = 8;
+                } if (left > (winWidth - width - 32)) {
+                    left = (winWidth - width - 26);
+                }
+                top = top + (ev.clientY - dragOY);
+                top = Math.max(10, top);
+                popup.style.top = '' + top + 'px';
+                popup.style.left = '' + Math.min(left, (winWidth - width - 10)) + 'px';
+                dragOX = ev.clientX; dragOY = ev.clientY;
             }
-            top = top + (ev.clientY - dragOY);
-            top = Math.max(10, top);
-            popup.style.top = '' + top + 'px';
-            popup.style.left = '' + Math.min(left, (winWidth - width - 10)) + 'px';
-            dragOX = ev.clientX; dragOY = ev.clientY;
+            upHandler = function(ev) {
+                ev.stopPropagation(); ev.preventDefault();
+                window.removeEventListener('mousemove', moveHandler, false);
+                window.removeEventListener('mouseup', upHandler, false);
+            }
+            tbar.addEventListener('mousedown', function(ev) {
+                ev.preventDefault(); ev.stopPropagation();
+                dragOX = ev.clientX; dragOY = ev.clientY;
+                window.addEventListener('mousemove', moveHandler, false);
+                window.addEventListener('mouseup', upHandler, false);
+            }, false);
         }
-        upHandler = function(ev) {
-            ev.stopPropagation(); ev.preventDefault();
-            window.removeEventListener('mousemove', moveHandler, false);
-            window.removeEventListener('mouseup', upHandler, false);
-        }
-        tbar.addEventListener('mousedown', function(ev) {
-            ev.preventDefault(); ev.stopPropagation();
-            dragOX = ev.clientX; dragOY = ev.clientY;
-            window.addEventListener('mousemove', moveHandler, false);
-            window.addEventListener('mouseup', upHandler, false);
-        }, false);
-
 
         popup.appendChild(tbar);
     }

--- a/js/domui.js
+++ b/js/domui.js
@@ -1,6 +1,6 @@
 /* -*- mode: javascript; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2010
 //
@@ -41,9 +41,9 @@ Browser.prototype.makeTooltip = function(ele, text)
 Browser.prototype.popit = function(ev, name, ele, opts)
 {
     var thisB = this;
-    if (!opts) 
+    if (!opts)
         opts = {};
-    if (!ev) 
+    if (!ev)
         ev = {};
 
     var width = opts.width || 200;
@@ -119,7 +119,7 @@ Browser.prototype.popit = function(ev, name, ele, opts)
             window.addEventListener('mousemove', moveHandler, false);
             window.addEventListener('mouseup', upHandler, false);
         }, false);
-                              
+
 
         popup.appendChild(tbar);
     }

--- a/js/feature-popup.js
+++ b/js/feature-popup.js
@@ -74,7 +74,12 @@ FeatureInfo.prototype._notifyClose = function() {
     }
 }
 
-Browser.prototype.featurePopup = function(ev, __ignored_feature, hit, tier) {
+Browser.prototype.featurePopup = function(ev, __ignored_feature, hit, tier, opts) {
+    if (!opts) {
+        opts = {};
+    }
+
+
     var hi = hit.length;
     var feature = --hi >= 0 ? hit[hi] : {};
     var group = --hi >= 0 ? hit[hi] : {};
@@ -189,7 +194,8 @@ Browser.prototype.featurePopup = function(ev, __ignored_feature, hit, tier) {
         table,
         {
             width: 450,
-            onClose: featureInfo._notifyClose.bind(featureInfo)
+            onClose: featureInfo._notifyClose.bind(featureInfo),
+            disableDrag: opts.disableDrag
         }
     );
 }

--- a/js/feature-popup.js
+++ b/js/feature-popup.js
@@ -1,6 +1,6 @@
 /* -*- mode: javascript; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2011
 //
@@ -184,9 +184,9 @@ Browser.prototype.featurePopup = function(ev, __ignored_feature, hit, tier) {
     }
 
     this.popit(
-        ev, 
+        ev,
         featureInfo.title || 'Feature',
-        table, 
+        table,
         {
             width: 450,
             onClose: featureInfo._notifyClose.bind(featureInfo)


### PR DESCRIPTION
Currently the featurePopup is designed so that it can be dragged around the page. From what I can see in the code, this is a deliberate design decision. Based on personal experience, I can see that there might be a need to have it so that it can't be dragged (one big reason in my experience is that some users might not want to be dragging the window, but they might want to select the title of the window to copy and paste it elsewhere: searching for a gene name in another tab or application, for example).

Given that there might be a reason why people would want to drag, and given that it should likely stay as the default design option, attached is a change that adds a new option to the browser: `disableFeaturePopupDrag`. If set to `true` dragging of the feature popup will be disabled; if set to `false` or omitted the default behaviour remains.

Apologies for the slight tidying of some trailing whitespace.