### PR TITLE
Force wrapping of value fields in the feature popup

### DIFF
--- a/css/dalliance-scoped.css
+++ b/css/dalliance-scoped.css
@@ -454,3 +454,7 @@
   text-align: center;
   margin-left: -21px;
 }
+
+.dalliance .popover-content td span {
+    word-break: break-word;
+}

--- a/css/dalliance-scoped.css
+++ b/css/dalliance-scoped.css
@@ -125,7 +125,7 @@
   background-image: -moz-linear-gradient(45deg, black 25%, transparent 25%, transparent 75%, black 75%, black),
                     -moz-linear-gradient(-45deg, black 25%, transparent 25%, transparent 75%, black 75%, black);
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc),
-                    linear-gradient(135deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc); 
+                    linear-gradient(135deg, #ccc 25%, transparent 25%, transparent 75%, #ccc 75%, #ccc);
 }
 
 *.dalliance .loc-field {


### PR DESCRIPTION
If a value appears in the feature popup, which has no whitespace and so has nothing that can be easily wrapped, the text bleeds out of the window:

![screenshot from 2018-01-31 09-32-11](https://user-images.githubusercontent.com/28237/35615811-30b55cb2-066b-11e8-9f1a-00cfccf3d247.png)

This pull request aims to fix that, giving this effect:

![screenshot from 2018-01-31 09-40-22](https://user-images.githubusercontent.com/28237/35615841-4495d9dc-066b-11e8-8adc-9f4882618f01.png)

Hopefully this is the correct approach to this; apologies if not, I wasn't 100% sure which stylesheet was the correct one to modify.