### PR TITLE
Allow clicking anywhere on the title to show/hide a section in a hub

### DIFF
--- a/js/domui.js
+++ b/js/domui.js
@@ -138,12 +138,6 @@ Browser.prototype.popit = function(ev, name, ele, opts)
 
 function makeTreeTableSection(title, content, visible) {
 
-    var showHide = function(ev) {
-        ev.preventDefault(); ev.stopPropagation();
-        visible = !visible;
-        update();
-    };
-
     var ttButton = makeElement('i');
     function update() {
         if (visible) {
@@ -155,6 +149,12 @@ function makeTreeTableSection(title, content, visible) {
         }
     }
     update();
+
+    var showHide = function(ev) {
+        ev.preventDefault(); ev.stopPropagation();
+        visible = !visible;
+        update();
+    };
 
     ttButton.addEventListener('click', showHide, false);
 

--- a/js/domui.js
+++ b/js/domui.js
@@ -137,6 +137,13 @@ Browser.prototype.popit = function(ev, name, ele, opts)
 }
 
 function makeTreeTableSection(title, content, visible) {
+
+    var showHide = function(ev) {
+        ev.preventDefault(); ev.stopPropagation();
+        visible = !visible;
+        update();
+    };
+
     var ttButton = makeElement('i');
     function update() {
         if (visible) {
@@ -149,13 +156,11 @@ function makeTreeTableSection(title, content, visible) {
     }
     update();
 
-    ttButton.addEventListener('click', function(ev) {
-        ev.preventDefault(); ev.stopPropagation();
-        visible = !visible;
-        update();
-    }, false);
+    ttButton.addEventListener('click', showHide, false);
 
     var heading = makeElement('h6', [ttButton, ' ', title], {}, {display: 'block', background: 'gray', color: 'white', width: '100%', padding: '5px 2px', margin: '0px'});
+    heading.addEventListener('click', showHide, false);
+
     return makeElement('div', [heading, content], {});
 }
 


### PR DESCRIPTION
This change lets the user click anywhere on a title of a section inside a custom hub, rather than having to click on the little arrow to the left of the title. The current design can be tricky for users on some displays, and can sometimes result in them clicking on the separator to the left of the arrow, which causes the whole hub area to close down.