### PR TITLE
Set the cursor of hub group headings to be a hand

### DIFF
--- a/js/domui.js
+++ b/js/domui.js
@@ -158,7 +158,7 @@ function makeTreeTableSection(title, content, visible) {
 
     ttButton.addEventListener('click', showHide, false);
 
-    var heading = makeElement('h6', [ttButton, ' ', title], {}, {display: 'block', background: 'gray', color: 'white', width: '100%', padding: '5px 2px', margin: '0px'});
+    var heading = makeElement('h6', [ttButton, ' ', title], {}, {display: 'block', background: 'gray', color: 'white', width: '100%', padding: '5px 2px', margin: '0px', cursor: 'pointer'});
     heading.addEventListener('click', showHide, false);
 
     return makeElement('div', [heading, content], {});


### PR DESCRIPTION
This makes it a little more obvious that you can click on the heading to do
something.