### PR TITLE
Have formatQuantLabel always show something

### DIFF
--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -4,7 +4,7 @@
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2013
 //
-// browser-us.js: standard UI wiring
+// browser-ui.js: standard UI wiring
 //
 
 "use strict";

--- a/js/cigar.js
+++ b/js/cigar.js
@@ -1,9 +1,9 @@
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2010
 //
-// chainset.js: liftover support
+// cigar.js: liftover support
 //
 
 var CIGAR_REGEXP = new RegExp('([0-9]*)([MIDS])', 'g');

--- a/js/numformats.js
+++ b/js/numformats.js
@@ -12,22 +12,7 @@ function formatLongInt(n) {
 }
 
 function formatQuantLabel(v) {
-    var t = '' + v;
-    var dot = t.indexOf('.');
-    if (dot < 0) {
-        return t;
-    } else {
-        var dotThreshold = 2;
-        if (t.substring(0, 1) == '-') {
-            ++dotThreshold;
-        }
-
-        if (dot >= dotThreshold) {
-            return t.substring(0, dot);
-        } else {
-            return t.substring(0, dot + 2);
-        }
-    }
+    return ( ( typeof v === "string" ) ? parseFloat( v ) : v ).toPrecision( 1 );
 }
 
 if (typeof(module) !== 'undefined') {

--- a/js/numformats.js
+++ b/js/numformats.js
@@ -1,6 +1,6 @@
 /* -*- mode: javascript; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2014
 //

--- a/js/numformats.js
+++ b/js/numformats.js
@@ -4,7 +4,7 @@
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2014
 //
-// memstore.js
+// numformats.js
 //
 
 function formatLongInt(n) {

--- a/js/probe.js
+++ b/js/probe.js
@@ -1,10 +1,10 @@
 /* -*- mode: javascript; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2014
 //
-// bedwig.js
+// probe.js
 //
 
 "use strict";

--- a/js/search.js
+++ b/js/search.js
@@ -1,10 +1,10 @@
 /* -*- mode: javascript; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-// 
+//
 // Dalliance Genome Explorer
 // (c) Thomas Down 2006-2011
 //
-// bin.js general binary data support
+// search.js general binary data support
 //
 
 "use strict";
@@ -36,7 +36,7 @@ Browser.prototype.search = function(g, statusCallback, opts) {
     var thisB = this;
     opts = opts || {};
     var srPadding = opts.padding || this.defaultSearchRegionPadding;
-    
+
     var m = REGION_PATTERN.exec(g);
 
     if (m) {
@@ -69,7 +69,7 @@ Browser.prototype.search = function(g, statusCallback, opts) {
             var nchr = null;
             for (var fi = 0; fi < found.length; ++fi) {
                 var f = found[fi];
-            
+
                 if (nchr == null) {
                     nchr = f.segment;
                 }
@@ -160,7 +160,7 @@ Browser.prototype.doDasSearch = function(source, g, searchCallback) {
         var found2 = [];
         for (var fi = 0; fi < found.length; ++fi) {
             var f = found[fi];
-            
+
             if (f.label.toLowerCase() != g.toLowerCase()) {
                 // ...because Dazzle can return spurious overlapping features.
                 continue;


### PR DESCRIPTION
The vertical scale of a track can be a little unhelpful if the min and max values are both very small. An example would be this:

![image](https://user-images.githubusercontent.com/28237/57234685-1af0e900-7019-11e9-964c-19501c3f6c9c.png)

The min and max values for that track are something like -0.03 and 0.03, but confusingly just show as -0.0 and 0.0.

This change modifies [`formatQuantLabel`](https://github.com/dasmoth/dalliance/blob/64565abc974433a5dcd5406d17fa0a202e1e55fc/js/numformats.js#L14) in a way that attempts to maintain current functionality while also allowing smaller values to appear.

I've also made this change such that it can handle having a string passed to it. I was far from certain if this was something that happens; a brief test suggested it didn't but I wanted to err on the safe side. If this change is useful and this particular aspect of it isn't necessary, do please feel free to correct.

The PR also includes a correction of the module name in the header comment.